### PR TITLE
Adjust Fanbox API headers to avoid 403 responses

### DIFF
--- a/lib/fetch_images/clients/fanbox.rb
+++ b/lib/fetch_images/clients/fanbox.rb
@@ -30,11 +30,11 @@ module FetchImages
         post_id = match[:id]
         creator = match[:creator]
         uri = URI.parse(url)
-        origin_host = uri.host == "www.fanbox.cc" ? "www.fanbox.cc" : "#{creator}.fanbox.cc"
-        origin = "#{uri.scheme}://#{origin_host}"
+        origin = "#{uri.scheme}://www.fanbox.cc"
+        referer = "#{origin}/@#{creator}/posts/#{post_id}"
         headers = {
           "Accept" => "application/json, text/plain, */*",
-          "Referer" => url,
+          "Referer" => referer,
           "Origin" => origin
         }
         apply_cookies("FANBOXSESSID" => session_id) if session_id


### PR DESCRIPTION
## Summary
- normalize Fanbox API requests to always use the www.fanbox.cc origin
- align referer header with the canonical www.fanbox.cc URL for posts

## Testing
- bundle exec ruby -c lib/fetch_images/clients/fanbox.rb

------
https://chatgpt.com/codex/tasks/task_e_68e467d9a014832c87c077658cf953a9